### PR TITLE
feat: linter for yaml files

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -10,6 +10,7 @@
     "njqdev.vscode-python-typehint",
     "evondev.indent-rainbow-palettes",
     "wayou.vscode-todo-highlight",
-    "huntertran.auto-markdown-toc"
+    "huntertran.auto-markdown-toc",
+    "augustocdias.tasks-shell-input"
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,12 +2,13 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "dekick debug",
+      "name": "dekick local",
       "type": "python",
       "request": "attach",
       "debugServer": 8753,
       "host": "localhost",
-      "justMyCode": false,
-    },
+      "justMyCode": false
+      // "preLaunchTask": "dekick local"
+    }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,50 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "dekick local",
+      "command": "dekick-docker.sh",
+      "args": ["local"],
+      "options": {
+        "env": {
+          "PROJECT_ROOT": "${input:projectRoot}",
+          "DEKICK_DEBUGGER": "true"
+        }
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+      },
+      "isBackground": true,
+      "problemMatcher": {
+        "pattern": [
+          {
+            "regexp": "^(.*):(\\d+):(\\d+):\\s+(warning|error):\\s+(.*)$",
+            "file": 1,
+            "line": 2,
+            "column": 3,
+            "severity": 4,
+            "message": 5
+          }
+        ],
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": "Waiting for debugger to attach on port 8753...",
+          "endsPattern": "DeKick was running"
+        }
+      }
+    }
+  ],
+  "inputs": [
+    {
+      "id": "projectRoot",
+      "type": "command",
+      "command": "shellCommand.execute",
+      "args": {
+        "command": "find $HOME -name .dekickrc.yml -type f -exec dirname {} \\;",
+        "fieldSeparator": "\n",
+        "description": "Select project root to debug"
+      }
+    }
+  ]
+}

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,31 @@
+---
+extends: default
+
+rules:
+  braces:
+    level: warning
+    max-spaces-inside: 1
+  brackets:
+    level: warning
+    max-spaces-inside: 1
+  colons:
+    level: warning
+  commas:
+    level: warning
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-values:
+    forbid-in-block-mappings: true
+    forbid-in-flow-mappings: true
+  empty-lines:
+    level: warning
+  hyphens:
+    level: warning
+  indentation:
+    level: warning
+    indent-sequences: consistent
+  line-length:
+    level: warning
+    allow-non-breakable-inline-mappings: true
+  truthy: disable

--- a/lib/global_config.py
+++ b/lib/global_config.py
@@ -17,16 +17,21 @@ def get_global_config_value(name: str):
     """Get value from .dekickrc.yml file"""
     dekickrc_flat = __get_dekickrc_global_flat()
 
-    if not name in dekickrc_flat:
-        print(
-            f"Key {C_CMD}{name}{C_END} does not exists in "
-            + f"{C_FILE}{DEKICKRC_GLOBAL_HOST_PATH}{C_END}")
-        sys.exit(1)
-
-    if dekickrc_flat[name] is None:
-        return ""
-
-    return dekickrc_flat[name]
+    try:
+        if not name in dekickrc_flat:
+            raise TypeError(
+                f"Key {name} does not exists in "
+                + f"{C_FILE}{DEKICKRC_GLOBAL_HOST_PATH}{C_END}"
+            )
+        value = dekickrc_flat[name]
+        if value is None:
+            return ""
+        return value
+    except TypeError as exception:
+        raise TypeError(
+            f"Key {name} does not exists in "
+            + f"{C_FILE}{DEKICKRC_GLOBAL_HOST_PATH}{C_END}"
+        ) from exception
 
 
 def __get_dekickrc_global_flat() -> flatdict.FlatDict:

--- a/lib/run_func.py
+++ b/lib/run_func.py
@@ -9,6 +9,7 @@ from rich.traceback import install
 
 from lib.logger import get_log_filename, log_exception
 from lib.settings import (
+    C_CMD,
     C_CODE,
     C_END,
     C_ERROR,
@@ -77,8 +78,10 @@ def run_func(
     except Exception as error:  # pylint: disable=broad-except
         log_file = get_log_filename()
         fail_text = (
-            f"{text} {C_ERROR}failed{C_END}\n  {error}\n  Please see {C_FILE}{log_file}{C_END}"
-            + " for more information"
+            f"{text} {C_ERROR}failed{C_END}\n  {error}\n\n  "
+            + f"Enable debug mode by adding {C_CMD}--log-level DEBUG{C_END} "
+            + f"and look into {C_FILE}{log_file}{C_END} "
+            + "for more information about the error"
         )
         spinner.fail(text=fail_text)
 

--- a/lib/yaml/linter.py
+++ b/lib/yaml/linter.py
@@ -1,0 +1,38 @@
+import sys
+
+from rich.console import Console
+from yamllint import config, linter
+
+from lib.settings import (
+    DEKICK_PATH,
+    DEKICKRC_GLOBAL_HOST_PATH,
+    DEKICKRC_GLOBAL_PATH,
+    PROJECT_ROOT,
+)
+
+console = Console()
+
+
+def lint(path):
+    """Lint a YAML file."""
+    yaml_config = config.YamlLintConfig(file=f"{DEKICK_PATH}/.yamllint.yml")
+
+    with open(path, "r", encoding="utf-8") as file:
+        description = list(linter.run(file, yaml_config))
+
+        if len(description) == 0:
+            return
+
+        path_reduced = path.replace(f"{PROJECT_ROOT}/", "")
+        path_reduced = path.replace(DEKICKRC_GLOBAL_PATH, DEKICKRC_GLOBAL_HOST_PATH)
+
+        error = (
+            "\nOoops, something terrible happened!\n\n"
+            + f"You have a syntax error in your [bold]{path_reduced}[/bold] YAML file:\n"
+        )
+
+        for desc in description:
+            error += f" - line {desc.line} has a {desc.desc}\n"
+
+        console.print(error)
+        sys.exit(1)

--- a/lib/yaml/reader.py
+++ b/lib/yaml/reader.py
@@ -6,6 +6,7 @@ import flatdict
 import yaml
 
 from lib.settings import C_END, C_FILE
+from lib.yaml.linter import lint
 
 
 def read_yaml(file) -> flatdict.FlatDict:
@@ -13,6 +14,8 @@ def read_yaml(file) -> flatdict.FlatDict:
     if not path.exists(file):
         print(f"File {C_FILE}{file}{C_END} does not exists")
         sys.exit(1)
+
+    lint(file)
 
     with (open(file, "r", encoding="utf-8")) as yaml_file:
         yaml_parsed = yaml.safe_load(yaml_file)

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ debugpy==1.6.5
 filelock==3.12.0
 humanfriendly==10.0
 hvac==1.1.0
+yamllint==1.31.0


### PR DESCRIPTION
Introducing linter for YAML files. Checks both `.dekickrc.yml` and `global.yml` for possible formatting errors and shows them to user.